### PR TITLE
Add support for named relations - minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,14 @@
     "gulp-rename": "^1.2.2",
     "gulp-tag-version": "^1.2.1",
     "gulp-util": "^3.0.4",
-    "le-storage-provider-firebase": "^2.0.3",
+    "le-storage-provider-firebase": "^2.1.0",
     "mocha": "^2.2.1",
     "run-sequence": "^1.0.2",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
+    "le-storage-provider-firebase": "^2.1.0",
     "pluralize": "^1.1.2",
     "q": "^1.2.0"
   }

--- a/src/collection-service.js
+++ b/src/collection-service.js
@@ -143,6 +143,7 @@ var CollectionService = function(provider, type) {
    * @param {...Object} config a map of properties to join on
    * @param {string} config.type the record type to join by
    * @param {boolean} config.many (optional) join with hasMany relation
+   * @param {boolean} config.as (optional) join with named relation
    * @returns {Promise} promise resolves with the combined data object
    */
   this.join = function() {
@@ -151,7 +152,7 @@ var CollectionService = function(provider, type) {
     var records = _collection.getRecords();
     var promises = [];
     for (var i = 0; i < records.length; i += 1) {
-      promises.push(records[i].join.apply(records[i], arguments)); //TODO: loop over args
+      promises.push(records[i].join.apply(records[i], arguments));
     }
     q.allSettled(promises).then(function(settledPromises) {
       var data = [];

--- a/src/record-service.js
+++ b/src/record-service.js
@@ -268,21 +268,37 @@ var RecordService = function(provider, type, id) {
     _provider.unsync(pluralize(caseConverter.toCamelCase(_type)), _id);
   }
 
-  function relateToOne(type) {
+  function relateToOne(type, as) {
     var _record = this;
-    this['get' + caseConverter.toSnakeCase(type)] = function() {
-      var id = _data[caseConverter.toCamelCase(type) + '_id'];
-      if (!id) {
-        return;
-      }
-      var record = new RecordService(_provider, type, id);
-      return record;
-    };
-    this['set' + caseConverter.toSnakeCase(type)] = function(record) {
-      var id = record.getID();
-      _data[caseConverter.toCamelCase(record.getType()) + '_id'] = id;
-      return _record;
-    };
+    if (as) {
+      this['get' + caseConverter.toSnakeCase(as)] = function() {
+        var id = _data[caseConverter.toCamelCase(as) + '_id'];
+        if (!id) {
+          return;
+        }
+        var record = new RecordService(_provider, type, id);
+        return record;
+      };
+      this['set' + caseConverter.toSnakeCase(as)] = function(record) {
+        var id = record.getID();
+        _data[caseConverter.toCamelCase(as) + '_id'] = id;
+        return _record;
+      };
+    } else {
+      this['get' + caseConverter.toSnakeCase(type)] = function() {
+        var id = _data[caseConverter.toCamelCase(type) + '_id'];
+        if (!id) {
+          return;
+        }
+        var record = new RecordService(_provider, type, id);
+        return record;
+      };
+      this['set' + caseConverter.toSnakeCase(type)] = function(record) {
+        var id = record.getID();
+        _data[caseConverter.toCamelCase(record.getType()) + '_id'] = id;
+        return _record;
+      };
+    }
   };
 
   function relateToMany(type) {

--- a/src/record-service.js
+++ b/src/record-service.js
@@ -84,6 +84,7 @@ var RecordService = function(provider, type, id) {
    * @memberof RecordService
    * @instance
    * @param {string} type the type of record this record has many of
+   * @param {string} as (optional) the name of the relation
    */
   this.relateToMany = relateToMany;
 
@@ -97,6 +98,7 @@ var RecordService = function(provider, type, id) {
    * @memberof RecordService
    * @instance
    * @param {string} type the type of record this record has one of
+   * @param {string} as (optional) the name of the relation
    */
   this.relateToOne = relateToOne;
 
@@ -301,29 +303,52 @@ var RecordService = function(provider, type, id) {
     }
   };
 
-  function relateToMany(type) {
+  function relateToMany(type, as) {
     var _record = this;
-    var _collection = new CollectionService(_provider, type);
-    this['get' + pluralize(caseConverter.toSnakeCase(type))] = function() {
-      _collection = new CollectionService(_provider, type);
-      if (_data[caseConverter.toCamelCase(type) + '_ids']) {
-        var ids = Object.keys(_data[caseConverter.toCamelCase(type) + '_ids']);
-        for (var i = 0; i < ids.length; i++) {
-          var record = new RecordService(_provider, type, ids[i]);
-          _collection.addRecord(record);
+    var _collection;
+    if (as) {
+      this['get' + pluralize(caseConverter.toSnakeCase(as))] = function() {
+        _collection = new CollectionService(_provider, type);
+        if (_data[caseConverter.toCamelCase(as) + '_ids']) {
+          var ids = Object.keys(_data[caseConverter.toCamelCase(as) + '_ids']);
+          for (var i = 0; i < ids.length; i++) {
+            var record = new RecordService(_provider, type, ids[i]);
+            _collection.addRecord(record);
+          }
         }
-      }
-      return _collection;
-    };
-    this['add' + caseConverter.toSnakeCase(type)] = function(record) {
-      var id = record.getID();
-      var ids = _data[caseConverter.toCamelCase(record.getType()) + '_ids'];
-      if (!ids) {
-        _data[caseConverter.toCamelCase(record.getType()) + '_ids'] = {};
-      }
-      _data[caseConverter.toCamelCase(record.getType()) + '_ids'][id] = true;
-      return _record;
-    };
+        return _collection;
+      };
+      this['add' + caseConverter.toSnakeCase(as)] = function(record) {
+        var id = record.getID();
+        var ids = _data[caseConverter.toCamelCase(as) + '_ids'];
+        if (!ids) {
+          _data[caseConverter.toCamelCase(as) + '_ids'] = {};
+        }
+        _data[caseConverter.toCamelCase(as) + '_ids'][id] = true;
+        return _record;
+      };
+    } else {
+      this['get' + pluralize(caseConverter.toSnakeCase(type))] = function() {
+        _collection = new CollectionService(_provider, type);
+        if (_data[caseConverter.toCamelCase(type) + '_ids']) {
+          var ids = Object.keys(_data[caseConverter.toCamelCase(type) + '_ids']);
+          for (var i = 0; i < ids.length; i++) {
+            var record = new RecordService(_provider, type, ids[i]);
+            _collection.addRecord(record);
+          }
+        }
+        return _collection;
+      };
+      this['add' + caseConverter.toSnakeCase(type)] = function(record) {
+        var id = record.getID();
+        var ids = _data[caseConverter.toCamelCase(record.getType()) + '_ids'];
+        if (!ids) {
+          _data[caseConverter.toCamelCase(record.getType()) + '_ids'] = {};
+        }
+        _data[caseConverter.toCamelCase(record.getType()) + '_ids'][id] = true;
+        return _record;
+      };
+    }
   };
 
   function join() {

--- a/src/record-service.js
+++ b/src/record-service.js
@@ -282,6 +282,7 @@ var RecordService = function(provider, type, id) {
         return record;
       };
       this['set' + caseConverter.toSnakeCase(as)] = function(record) {
+        if (record.getType() !== type) { throw new Error('Invalid type. Expecting "' + type + '", but saw "' + record.getType() + '"'); }
         var id = record.getID();
         _data[caseConverter.toCamelCase(as) + '_id'] = id;
         return _record;
@@ -319,6 +320,7 @@ var RecordService = function(provider, type, id) {
         return _collection;
       };
       this['add' + caseConverter.toSnakeCase(as)] = function(record) {
+        if (record.getType() !== type) { throw new Error('Invalid type. Expecting "' + type + '", but saw "' + record.getType() + '"'); }
         var id = record.getID();
         var ids = _data[caseConverter.toCamelCase(as) + '_ids'];
         if (!ids) {

--- a/src/storage-service.js
+++ b/src/storage-service.js
@@ -48,7 +48,7 @@ var StorageService = function(provider) {
    * @param {string} type the type of records in collection, required
    * @param {string} orderBy the name of the field to order the records by
    *                         and to check the equalTo value against, required if using equalTo
-   * @param {string, number, null, or boolean} equalTo the value to compare the field
+   * @param {string|number|null|boolean} equalTo the value to compare the field
    *                         specified in orderBy against and only add records that
    *                         have the matching value in the specified field
    * @param {number} limit the maximum number of records to be placed in the collection

--- a/test/e2e/firebase-provider/scenario.js
+++ b/test/e2e/firebase-provider/scenario.js
@@ -141,6 +141,9 @@ function testRecordJoin() {
         rootRecordForJoin.relateToOne('Dog');
         rootRecordForJoin.setDog(singleRelationExisting);
 
+        rootRecordForJoin.relateToMany('Child', 'Favorite');
+        rootRecordForJoin.addFavorite(joinedChildRecord1);
+
         var promises = [];
         promises.push(rootRecordForJoin.save());
         promises.push(deletedRecord.save());
@@ -175,6 +178,19 @@ function testRecordJoin() {
           done();
         }, function(err) {
           console.log(err);
+        });
+      })
+    });
+
+    it('should support named relations', function() {
+      return storage.fetchRecord('Parent', rootRecordForJoin_id).then(function(record) {
+        return record.join({
+          type: 'Child',
+          many: true,
+          as: 'Favorite'
+        }).then(function(data) {
+          expect(data.favorites).to.have.length(1);
+          expect(data.favorites[0]._id).to.equal(joinedChildRecord1_id);
         });
       })
     });
@@ -456,11 +472,11 @@ function testRelatesAs() {
 
 function runTests () {
   describe('le-storage-service e2e tests', function () {
-    /*after(function() {
+    after(function() {
       setTimeout(function() {
         process.exit(0);
       }, 1000);
-    });*/
+    });
     this.timeout(10000);
     testFetchRecord();
     testUpdateRecordWithInvalidData();

--- a/test/unit/record-service.js
+++ b/test/unit/record-service.js
@@ -152,6 +152,16 @@ describe('RecordService', function() {
     expect(record.getToys).not.to.be.undefined;
     expect(record.addToy).not.to.be.undefined;
   });
+  it('should support named one-to-many relations', function() {
+    var record = new RecordService(mockStorageProvider, type, id);
+    expect(record.getToys).to.be.undefined;
+    expect(record.addToy).to.be.undefined;
+    record.relateToMany('Toy', 'Gift');
+    expect(record.getGifts).not.to.be.undefined;
+    expect(record.addGift).not.to.be.undefined;
+    expect(record.getToys).to.be.undefined;
+    expect(record.addToy).to.be.undefined;
+  });
   it('should store and retrive data locally', function() {
     var record = new RecordService(mockStorageProvider, type, id);
     record.setData({

--- a/test/unit/record-service.js
+++ b/test/unit/record-service.js
@@ -134,6 +134,16 @@ describe('RecordService', function() {
     expect(record.getPerson).not.to.be.undefined;
     expect(record.setPerson).not.to.be.undefined;
   });
+  it('should support named one-to-one relations', function() {
+    var record = new RecordService(mockStorageProvider, type, id);
+    expect(record.getPerson).to.be.undefined;
+    expect(record.setPerson).to.be.undefined;
+    record.relateToOne('Cat', 'Pet');
+    expect(record.getPet).not.to.be.undefined;
+    expect(record.setPet).not.to.be.undefined;
+    expect(record.getCat).to.be.undefined;
+    expect(record.setCat).to.be.undefined;
+  });
   it('should relate one record to many others', function() {
     var record = new RecordService(mockStorageProvider, type, id);
     expect(record.getToys).to.be.undefined;


### PR DESCRIPTION
`relatesToOne`, `relatesToMany`, and `join` now support `as` parameters that allow you to name your relations (defaults to the name of the related type).
