### PR TITLE
feat(record-service): add removeX function when relateToMany is used. - minor

### DIFF
--- a/src/record-service.js
+++ b/src/record-service.js
@@ -334,6 +334,14 @@ var RecordService = function(provider, type, id) {
         _data[pluralize(caseConverter.toCamelCase(as))][id] = true;
         return _record;
       };
+      this['remove' + caseConverter.toSnakeCase(as)] = function(record) {
+        if (record.getType() !== type) {
+          throw new Error('Invalid type. Expecting "' + type + '", but saw "' + record.getType() + '"');
+        }
+        var id = record.getID();
+        delete _data[pluralize(caseConverter.toCamelCase(as))][id];
+        return _record;
+      };
     } else {
       this['get' + pluralize(caseConverter.toSnakeCase(type))] = function() {
         _collection = new CollectionService(_provider, type);
@@ -353,6 +361,11 @@ var RecordService = function(provider, type, id) {
           _data[caseConverter.toCamelCase(record.getType()) + '_ids'] = {};
         }
         _data[caseConverter.toCamelCase(record.getType()) + '_ids'][id] = true;
+        return _record;
+      };
+      this['remove' + caseConverter.toSnakeCase(type)] = function(record) {
+        var id = record.getID();
+        delete _data[caseConverter.toCamelCase(record.getType()) + '_ids'][id];
         return _record;
       };
     }

--- a/test/unit/record-service.js
+++ b/test/unit/record-service.js
@@ -148,19 +148,24 @@ describe('RecordService', function() {
     var record = new RecordService(mockStorageProvider, type, id);
     expect(record.getToys).to.be.undefined;
     expect(record.addToy).to.be.undefined;
+    expect(record.removeToy).to.be.undefined;
     record.relateToMany('Toy');
     expect(record.getToys).not.to.be.undefined;
     expect(record.addToy).not.to.be.undefined;
+    expect(record.removeToy).not.to.be.undefined;
   });
   it('should support named one-to-many relations', function() {
     var record = new RecordService(mockStorageProvider, type, id);
     expect(record.getToys).to.be.undefined;
     expect(record.addToy).to.be.undefined;
+    expect(record.removeToy).to.be.undefined;
     record.relateToMany('Toy', 'Gift');
     expect(record.getGifts).not.to.be.undefined;
     expect(record.addGift).not.to.be.undefined;
+    expect(record.removeGift).not.to.be.undefined;
     expect(record.getToys).to.be.undefined;
     expect(record.addToy).to.be.undefined;
+    expect(record.removeToy).to.be.undefined;
   });
   it('should store and retrive data locally', function() {
     var record = new RecordService(mockStorageProvider, type, id);


### PR DESCRIPTION
Fixes #27
